### PR TITLE
Desabilitar Transaction (soft delete)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.1.1",
     "@radix-ui/react-dialog": "^1.1.1",
+    "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.0.2",
     "@radix-ui/react-popover": "^1.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-dialog':
         specifier: ^1.1.1
         version: 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-dropdown-menu':
+        specifier: ^2.1.1
+        version: 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-icons':
         specifier: ^1.3.0
         version: 1.3.0(react@18.3.1)
@@ -1598,6 +1601,19 @@ packages:
       '@types/react-dom':
         optional: true
 
+  '@radix-ui/react-dropdown-menu@2.1.1':
+    resolution: {integrity: sha512-y8E+x9fBq9qvteD2Zwa4397pUVhYsh9iq44b5RD5qu1GMJWBCBuVg1hMyItbc6+zH00TxGRqd9Iot4wzf3OoBQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-focus-guards@1.0.1':
     resolution: {integrity: sha512-Rect2dWbQ8waGzhMavsIbmSVCgYxkXLxxR3ZvCX79JOglzdEy4JXMb98lq4hPxUbLr77nP0UOGf4rcMU+s1pUA==}
     peerDependencies:
@@ -1667,6 +1683,19 @@ packages:
 
   '@radix-ui/react-label@2.1.0':
     resolution: {integrity: sha512-peLblDlFw/ngk3UWq0VnYaOLy6agTZZ+MUO/WhVfm14vJGML+xH4FAl2XQGLqdefjNb7ApRg6Yn7U42ZhmYXdw==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-menu@2.1.1':
+    resolution: {integrity: sha512-oa3mXRRVjHi6DZu/ghuzdylyjaMXLymx83irM7hTxutQbD+7IhPKdMdRHD26Rm+kHRrWcrUkkRPv5pd47a2xFQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6029,6 +6058,21 @@ snapshots:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0
 
+  '@radix-ui/react-dropdown-menu@2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-menu': 2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
   '@radix-ui/react-focus-guards@1.0.1(@types/react@18.3.3)(react@18.3.1)':
     dependencies:
       '@babel/runtime': 7.24.8
@@ -6089,6 +6133,32 @@ snapshots:
       '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.3
+      '@types/react-dom': 18.3.0
+
+  '@radix-ui/react-menu@2.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.0
+      '@radix-ui/react-collection': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-compose-refs': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-direction': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-dismissable-layer': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-focus-guards': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-focus-scope': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-id': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-popper': 1.2.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-portal': 1.1.1(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-presence': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-primitive': 2.0.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-roving-focus': 1.1.0(@types/react-dom@18.3.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-slot': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.3.3)(react@18.3.1)
+      aria-hidden: 1.2.4
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-remove-scroll: 2.5.7(@types/react@18.3.3)(react@18.3.1)
     optionalDependencies:
       '@types/react': 18.3.3
       '@types/react-dom': 18.3.0

--- a/src/components/DisableButton/index.tsx
+++ b/src/components/DisableButton/index.tsx
@@ -1,8 +1,0 @@
-import { Trash2 } from "lucide-react";
-
-export default function DisableButton() {
-
-    return (
-        <div className="bg-red p-2 rounded-lg hover:brightness-75 cursor-pointer"><Trash2 color="background" size={16} /></div>
-    )
-}

--- a/src/components/Summary/index.tsx
+++ b/src/components/Summary/index.tsx
@@ -8,10 +8,10 @@ export default function Summary() {
 
     const summary = transactions.reduce((acc, transaction) => {
 
-        if (transaction.type === "deposit") {
+        if (transaction.type === "deposit" && transaction.isActive) {
             acc.deposits += transaction.amount;
             acc.total += transaction.amount;
-        } else {
+        } else if (transaction.isActive) {
             acc.withdraws += transaction.amount;
             acc.total -= transaction.amount;
         }

--- a/src/components/TransactionsTable/columns.tsx
+++ b/src/components/TransactionsTable/columns.tsx
@@ -1,9 +1,21 @@
 "use client"
 
 import { ColumnDef } from "@tanstack/react-table"
-import { TransactionProps } from "@/stores/TransactionStore"
+import { TransactionProps, useTransactionStore } from "@/stores/TransactionStore"
 import { ArrowUpDown } from "lucide-react"
-import { Button } from "../ui/button"
+import { Trash2 } from "lucide-react"
+import { Button } from "@/components/ui/button"
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogFooter,
+  DialogClose,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { useState } from "react"
 
 export const columns: ColumnDef<TransactionProps>[] = [
   {
@@ -91,6 +103,45 @@ export const columns: ColumnDef<TransactionProps>[] = [
       }).format(date)
 
       return <div className="font-medium">{formatted}</div>
+    },
+  },
+  {
+    id: "disable",
+    header: () => <div>Desativar</div>,
+    cell: ({ row }) => {
+      let [open, setOpen] = useState(false);
+      let transactionStore = useTransactionStore();
+
+      let { disableTransaction } = transactionStore;
+
+      const disableButton = () => {
+        const transaction = row.original;
+
+        disableTransaction({...transaction, isActive: false});
+
+        console.log(transaction)
+        setOpen(false);
+      }
+
+      return (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogTrigger>
+            <Trash2 color="red" size={"18px"}></Trash2>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Desativar Produto</DialogTitle>
+            </DialogHeader>
+            <DialogDescription>Deseja realmente desativar o produto?</DialogDescription>
+            <DialogFooter>
+              <div className="flex justify-end gap-4">
+                <DialogClose><Button variant="ghost" className='border'>Cancelar</Button></DialogClose>
+                <Button onClick={disableButton}>Desabilitar</Button>
+              </div>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      )
     },
   },
 ]

--- a/src/components/TransactionsTable/index.tsx
+++ b/src/components/TransactionsTable/index.tsx
@@ -1,5 +1,5 @@
 import { useEffect } from "react";
-import { useTransactionStore } from "@/stores/TransactionStore";
+import { TransactionProps, useTransactionStore } from "@/stores/TransactionStore";
 import { DataTable } from "./data-table"
 import { columns } from "./columns"
 
@@ -12,11 +12,19 @@ export default function TransactionsTable() {
         fetchData();
     }, []);
 
+    let transactionsActive: TransactionProps[] = [];
+
+    transactions.forEach(transaction => {
+        if (transaction.isActive) {
+            transactionsActive.push(transaction);
+        }
+    })
+
     return (
         <div className="bg-white border rounded-lg p-2 w-10/12 m-auto mt-20">
             { isLoading && <div className="p-3">Carregando...</div> }
 
-            <DataTable columns={columns} data={transactions} />
+            <DataTable columns={columns} data={transactionsActive} />
         </div>
     )
 }

--- a/src/components/UpdateButton/index.tsx
+++ b/src/components/UpdateButton/index.tsx
@@ -1,7 +1,0 @@
-import { Pen } from "lucide-react";
-
-export default function UpdateButton() {
-    return(
-        <div className="bg-blue p-2 rounded-lg hover:brightness-75 cursor-pointer"><Pen color="background" size={16}/></div>
-    )
-}

--- a/src/services/actions/transactionsActions.ts
+++ b/src/services/actions/transactionsActions.ts
@@ -1,5 +1,5 @@
 import { db } from '../../../firebaseConfig';
-import { doc, setDoc } from "firebase/firestore";
+import { doc, setDoc, updateDoc } from "firebase/firestore";
 import { getTransactionsAccess } from "../dataAccess/transactionsAccess";
 import { TransactionProps } from "@/stores/TransactionStore";
 
@@ -22,4 +22,9 @@ export async function getTransactionsAction() {
 export async function addTransactionsAction(transaction: TransactionProps) {
     const docRef = doc(db, "transactions", transaction.id);
     await setDoc(docRef, transaction);
+}
+
+export async function updateTransactionsAction(transaction: TransactionProps) {
+    const docRef = doc(db, "transactions", transaction.id);
+    await updateDoc(docRef, transaction);
 }

--- a/src/stores/TransactionStore.ts
+++ b/src/stores/TransactionStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { toast } from "sonner";
-import {addTransactionsAction, getTransactionsAction } from "@/services/actions/transactionsActions";
+import {addTransactionsAction, getTransactionsAction, updateTransactionsAction } from "@/services/actions/transactionsActions";
 import { v4 as uuidv4 } from 'uuid';
 
 export type TransactionProps = {
@@ -22,6 +22,7 @@ type TransactionStoreProps = {
     error: null | string | unknown,
     fetchData: () => void,
     addTransaction: (transaction: Omit<TransactionProps, "id">) => void,
+    disableTransaction: (transaction: TransactionProps) => void,
 }
 
 export const useTransactionStore = create<TransactionStoreProps>()((set) => ({
@@ -45,6 +46,18 @@ export const useTransactionStore = create<TransactionStoreProps>()((set) => ({
                 transactions: [...state.transactions, data]
             }))
             toast.success("Transação adicionada!");
+        } catch (error) {
+            set({ error })
+        }
+    },
+    disableTransaction: async (transaction) => {
+        const data = transaction;
+        await updateTransactionsAction(data)
+        try {
+            set((state) => ({
+                transactions: state.transactions.map((transaction) => transaction.id === data.id? {...transaction, isActive: false } : transaction)
+            }))
+            toast.success("Transação desativada!");
         } catch (error) {
             set({ error })
         }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c0d19486-6656-4a9b-8a00-4e86d7d9d923)
Inicialmente estava desenvolvendo a lógica de controlar as transições ativas direto nas requisições no banco, mas visando diminuir a quantidade de requisições (iria ter que implementar outro método e ficar alternando) preferi fazer a lógica pelo frontend.

Posteriormente, vou permitir a listagem das transações inativas, assim como sua reativação.
