### PR TITLE
Adicionar cartões de crédito nas transações

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "lucide-react": "^0.394.0",
     "pnpm": "^9.3.0",
     "react": "^18.2.0",
+    "react-credit-cards-2": "^1.0.3",
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.2.0",
     "react-hook-form": "^7.51.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,9 @@ importers:
       react:
         specifier: ^18.2.0
         version: 18.3.1
+      react-credit-cards-2:
+        specifier: ^1.0.3
+        version: 1.0.3(react@18.3.1)
       react-day-picker:
         specifier: ^8.10.1
         version: 8.10.1(date-fns@3.6.0)(react@18.3.1)
@@ -2602,6 +2605,9 @@ packages:
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     hasBin: true
 
+  credit-card-type@9.1.0:
+    resolution: {integrity: sha512-CpNFuLxiPFxuZqhSKml3M+t0K/484pMAnfYWH14JoD7OZMnmC0Lmo+P7JX9SobqFpRoo7ifA18kOHdxJywYPEA==}
+
   cross-spawn@7.0.3:
     resolution: {integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==}
     engines: {node: '>= 8'}
@@ -2667,6 +2673,14 @@ packages:
   deepmerge@4.3.1:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
+
+  define-data-property@1.1.4:
+    resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
+    engines: {node: '>= 0.4'}
+
+  define-properties@1.2.1:
+    resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
+    engines: {node: '>= 0.4'}
 
   delayed-stream@1.0.0:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
@@ -2739,6 +2753,14 @@ packages:
 
   error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
+
+  es-define-property@1.0.0:
+    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
+    engines: {node: '>= 0.4'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
 
   esbuild@0.21.5:
     resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
@@ -2922,6 +2944,10 @@ packages:
   get-func-name@2.0.2:
     resolution: {integrity: sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==}
 
+  get-intrinsic@1.2.4:
+    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
+    engines: {node: '>= 0.4'}
+
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
     engines: {node: '>=6'}
@@ -2962,9 +2988,16 @@ packages:
     resolution: {integrity: sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==}
     engines: {node: '>=8'}
 
+  globalthis@1.0.4:
+    resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
+    engines: {node: '>= 0.4'}
+
   globby@11.1.0:
     resolution: {integrity: sha512-jhIXaOzy1sb8IyocaruWSn1TjmnBVs8Ayhcy83rmxNJ8q2uWKCAj3CnJY+KpGSXCueAPc0i05kVvVKtP1t9S3g==}
     engines: {node: '>=10'}
+
+  gopd@1.0.1:
+    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
 
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
@@ -2982,6 +3015,17 @@ packages:
   has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
+
+  has-property-descriptors@1.0.2:
+    resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
+
+  has-proto@1.0.3:
+    resolution: {integrity: sha512-SJ1amZAJUiZS+PhsVLf5tGydlaVB8EdFpaSO4gmiUKUOxk8qzn5AIy4ZeJUmh22znIdk/uMAUT2pl3FxzVUH+Q==}
+    engines: {node: '>= 0.4'}
+
+  has-symbols@1.0.3:
+    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
+    engines: {node: '>= 0.4'}
 
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
@@ -3400,6 +3444,10 @@ packages:
   lucide@0.394.0:
     resolution: {integrity: sha512-7nylApx46INfMFY8jsLetyoxnDJh+AXnemBOddEI96o9hopEZD8VCcqc+s+wwIOaJWhepwzZKidNIOIxGsH6Tw==}
 
+  luhn@2.4.1:
+    resolution: {integrity: sha512-p1eEWSb2RJAfv+BzrPEUqbUXV1H3ylHEAOk9yDM1L12ojD6OQQGrE29DqKLa0XYluJTIwXIOFmyzVOme3QSyww==}
+    engines: {node: '>=10'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -3584,6 +3632,10 @@ packages:
     resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
     engines: {node: '>= 6'}
 
+  object-keys@1.1.1:
+    resolution: {integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==}
+    engines: {node: '>= 0.4'}
+
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
 
@@ -3666,6 +3718,9 @@ packages:
   pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
+
+  payment@2.4.7:
+    resolution: {integrity: sha512-5HyD3HJ0q3XtVm/Dss4t3KGtIughkCfnyQ1WfMashVD2vvBOmuXnkswhBcknMcHW8oo4zqVnNbQSkNaqafYaGA==}
 
   picocolors@1.0.1:
     resolution: {integrity: sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew==}
@@ -3765,11 +3820,19 @@ packages:
   pure-rand@6.1.0:
     resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
 
+  qj@2.0.0:
+    resolution: {integrity: sha512-8466vlnAF/piI42tzMBUfhaAWn2yBNPOLSSbA2YBlEh+S8CxBXbAO1AwuDReGKYX6LlsK19wBL9cpXZGlgsXxA==}
+
   querystringify@2.2.0:
     resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  react-credit-cards-2@1.0.3:
+    resolution: {integrity: sha512-r4oi/92oUbDD7reCwOavjOZVJKpM941K3XYekUhVQysXEDxkzW8OGr0oD4Y5kYounJT2t75kbiEvERzRQS/shA==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   react-day-picker@8.10.1:
     resolution: {integrity: sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==}
@@ -7292,6 +7355,8 @@ snapshots:
       - supports-color
       - ts-node
 
+  credit-card-type@9.1.0: {}
+
   cross-spawn@7.0.3:
     dependencies:
       path-key: 3.1.1
@@ -7335,6 +7400,18 @@ snapshots:
   deep-is@0.1.4: {}
 
   deepmerge@4.3.1: {}
+
+  define-data-property@1.1.4:
+    dependencies:
+      es-define-property: 1.0.0
+      es-errors: 1.3.0
+      gopd: 1.0.1
+
+  define-properties@1.2.1:
+    dependencies:
+      define-data-property: 1.1.4
+      has-property-descriptors: 1.0.2
+      object-keys: 1.1.1
 
   delayed-stream@1.0.0: {}
 
@@ -7385,6 +7462,12 @@ snapshots:
   error-ex@1.3.2:
     dependencies:
       is-arrayish: 0.2.1
+
+  es-define-property@1.0.0:
+    dependencies:
+      get-intrinsic: 1.2.4
+
+  es-errors@1.3.0: {}
 
   esbuild@0.21.5:
     optionalDependencies:
@@ -7660,6 +7743,14 @@ snapshots:
 
   get-func-name@2.0.2: {}
 
+  get-intrinsic@1.2.4:
+    dependencies:
+      es-errors: 1.3.0
+      function-bind: 1.1.2
+      has-proto: 1.0.3
+      has-symbols: 1.0.3
+      hasown: 2.0.2
+
   get-nonce@1.0.1: {}
 
   get-package-type@0.1.0: {}
@@ -7700,6 +7791,11 @@ snapshots:
     dependencies:
       type-fest: 0.20.2
 
+  globalthis@1.0.4:
+    dependencies:
+      define-properties: 1.2.1
+      gopd: 1.0.1
+
   globby@11.1.0:
     dependencies:
       array-union: 2.1.0
@@ -7708,6 +7804,10 @@ snapshots:
       ignore: 5.3.1
       merge2: 1.4.1
       slash: 3.0.0
+
+  gopd@1.0.1:
+    dependencies:
+      get-intrinsic: 1.2.4
 
   graceful-fs@4.2.11: {}
 
@@ -7718,6 +7818,14 @@ snapshots:
   has-flag@3.0.0: {}
 
   has-flag@4.0.0: {}
+
+  has-property-descriptors@1.0.2:
+    dependencies:
+      es-define-property: 1.0.0
+
+  has-proto@1.0.3: {}
+
+  has-symbols@1.0.3: {}
 
   hasown@2.0.2:
     dependencies:
@@ -8317,6 +8425,8 @@ snapshots:
 
   lucide@0.394.0: {}
 
+  luhn@2.4.1: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.11:
@@ -8404,6 +8514,8 @@ snapshots:
 
   object-hash@3.0.0: {}
 
+  object-keys@1.1.1: {}
+
   once@1.4.0:
     dependencies:
       wrappy: 1.0.2
@@ -8480,6 +8592,11 @@ snapshots:
   pathe@1.1.2: {}
 
   pathval@2.0.0: {}
+
+  payment@2.4.7:
+    dependencies:
+      globalthis: 1.0.4
+      qj: 2.0.0
 
   picocolors@1.0.1: {}
 
@@ -8578,9 +8695,18 @@ snapshots:
 
   pure-rand@6.1.0: {}
 
+  qj@2.0.0: {}
+
   querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
+
+  react-credit-cards-2@1.0.3(react@18.3.1):
+    dependencies:
+      credit-card-type: 9.1.0
+      luhn: 2.4.1
+      payment: 2.4.7
+      react: 18.3.1
 
   react-day-picker@8.10.1(date-fns@3.6.0)(react@18.3.1):
     dependencies:

--- a/src/components/CreditCard/index.tsx
+++ b/src/components/CreditCard/index.tsx
@@ -1,0 +1,230 @@
+import { useState, ChangeEvent, FocusEvent } from 'react';
+import Cards from 'react-credit-cards-2';
+import 'react-credit-cards-2/dist/es/styles-compiled.css';
+
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "../ui/form";
+import { Input } from '../ui/input';
+import {
+    Dialog,
+    DialogContent,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogTrigger,
+    DialogClose,
+} from "@/components/ui/dialog";
+import { Button } from '../ui/button';
+import { Plus } from 'lucide-react';
+import { useCreditCardStore } from '@/stores/CreditCardStore';
+
+type FocusedField = 'number' | 'expiry' | 'cvc' | 'name' | '';
+
+interface PaymentFormState {
+    number: string;
+    expiry: string;
+    cvc: string;
+    name: string;
+    focus: FocusedField;
+}
+
+const formSchema = z.object({
+    alias: z.string().min(1, { message: "Este campo deve ser preenchido" }),
+    number: z.string().min(13, { message: "O número do cartão deve conter 13 caracteres" }),
+    expiry: z.string().min(4, { message: "Este campo deve ser preenchido" }),
+    cvc: z.string().min(3, { message: "Este campo deve ser preenchido" }).max(3, { message: "Este campo possuí apenas 3 digitos" }),
+    name: z.string().min(1, { message: "Este campo deve ser preenchido" }),
+})
+
+export default function CreditCard() {
+    let [open, setOpen] = useState(false);
+    const [state, setState] = useState<PaymentFormState>({
+        number: '',
+        expiry: '',
+        cvc: '',
+        name: '',
+        focus: '',
+    });
+
+    const creditCardStore = useCreditCardStore();
+
+    const { addCreditCard } = creditCardStore;
+
+    const form = useForm<z.infer<typeof formSchema>>({
+        resolver: zodResolver(formSchema),
+        defaultValues: {
+            alias: '',
+            number: '',
+            expiry: '',
+            cvc: '',
+            name: '',
+        }
+    });
+
+    const handleInputChange = (evt: ChangeEvent<HTMLInputElement>) => {
+        const { name, value } = evt.target;
+
+        setState((prev) => ({ ...prev, [name]: value }));
+    }
+
+    const handleInputFocus = (evt: FocusEvent<HTMLInputElement>) => {
+        setState((prev) => ({ ...prev, focus: evt.target.name as FocusedField }));
+    }
+
+    function onSubmit(values: z.infer<typeof formSchema>) {
+        addCreditCard({ ...values, userId: "" })
+        form.reset();
+        setOpen(false);
+    }
+
+    return (
+        <Dialog open={open} onOpenChange={setOpen}>
+            <DialogTrigger asChild>
+                <Button
+                    type="button"
+                    variant={"ghost"}
+                    className="gap-2"
+                >
+                    <Plus size={16}></Plus>
+                    Cadastrar novo
+                </Button>
+            </DialogTrigger>
+            <DialogContent>
+                <DialogHeader>
+                    <DialogTitle>Cadastrar cartão de crédito</DialogTitle>
+                </DialogHeader>
+                <div className='flex flex-col items-center gap-5 mt-3'>
+                    <Cards
+                        number={state.number}
+                        expiry={state.expiry}
+                        cvc={state.cvc}
+                        name={state.name}
+                        focused={state.focus}
+                    />
+                    <Form {...form}>
+                        <form onSubmit={
+                            e => {
+                                e.stopPropagation();
+                                form.handleSubmit(onSubmit)(e)
+                            }}>
+
+                            <FormField
+                                control={form.control}
+                                name="alias"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel></FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                placeholder="Apelido do cartão"
+                                                {...field}
+                                                onChange={event => field.onChange(event.target.value)}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="number"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel></FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                type="number"
+                                                name="number"
+                                                placeholder="Número do cartão"
+                                                value={state.number}
+                                                onChange={handleInputChange}
+                                                onFocus={handleInputFocus}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <FormField
+                                control={form.control}
+                                name="name"
+                                render={({ field }) => (
+                                    <FormItem>
+                                        <FormLabel></FormLabel>
+                                        <FormControl>
+                                            <Input
+                                                type="name"
+                                                name="name"
+                                                placeholder="Nome"
+                                                value={state.name}
+                                                onChange={handleInputChange}
+                                                onFocus={handleInputFocus}
+                                            />
+                                        </FormControl>
+                                        <FormMessage />
+                                    </FormItem>
+                                )}
+                            />
+
+                            <div className='flex gap-3'>
+                                <FormField
+                                    control={form.control}
+                                    name="expiry"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel></FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    type="expiry"
+                                                    name="expiry"
+                                                    placeholder="Data expiração (MM/AA)"
+                                                    value={state.expiry}
+                                                    onChange={handleInputChange}
+                                                    onFocus={handleInputFocus}
+
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={form.control}
+                                    name="expiry"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <FormLabel></FormLabel>
+                                            <FormControl>
+                                                <Input
+                                                    type="cvc"
+                                                    name="cvc"
+                                                    placeholder="CVC"
+                                                    value={state.cvc}
+                                                    onChange={handleInputChange}
+                                                    onFocus={handleInputFocus}
+
+                                                />
+                                            </FormControl>
+                                            <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+                            </div>
+
+                            <DialogFooter className='mt-5'>
+                                <DialogClose asChild><Button variant="ghost" className='border'>Cancelar</Button></DialogClose>
+                                <Button type="submit">Salvar</Button>
+                            </DialogFooter>
+                        </form>
+                    </Form>
+                </div>
+            </DialogContent>
+        </Dialog>
+    );
+}
+

--- a/src/components/CreditCard/index.tsx
+++ b/src/components/CreditCard/index.tsx
@@ -19,6 +19,7 @@ import {
 import { Button } from '../ui/button';
 import { Plus } from 'lucide-react';
 import { useCreditCardStore } from '@/stores/CreditCardStore';
+import { useAuthStore } from '@/stores/AuthStore';
 
 type FocusedField = 'number' | 'expiry' | 'cvc' | 'name' | '';
 
@@ -32,9 +33,9 @@ interface PaymentFormState {
 
 const formSchema = z.object({
     alias: z.string().min(1, { message: "Este campo deve ser preenchido" }),
-    number: z.string().min(13, { message: "O número do cartão deve conter 13 caracteres" }),
-    expiry: z.string().min(4, { message: "Este campo deve ser preenchido" }),
-    cvc: z.string().min(3, { message: "Este campo deve ser preenchido" }).max(3, { message: "Este campo possuí apenas 3 digitos" }),
+    number: z.coerce.number({ invalid_type_error: "Esse campo aceita apenas números" }).min(13, { message: "O número do cartão deve conter no mínimo 13 caracteres" }),
+    expiry: z.string().min(1, { message: "Este campo deve ser preenchido" }).max(4, { message: "Data inválida" }),
+    cvc: z.coerce.number({ invalid_type_error: "Esse campo aceita apenas números" }).min(3, { message: "O CVC possuí 3 digitos" }),
     name: z.string().min(1, { message: "Este campo deve ser preenchido" }),
 })
 
@@ -49,16 +50,20 @@ export default function CreditCard() {
     });
 
     const creditCardStore = useCreditCardStore();
+    let authStore = useAuthStore();
 
+    let { user, getUserInfo } = authStore;
     const { addCreditCard } = creditCardStore;
+
+    const decryptedUser = getUserInfo(user)
 
     const form = useForm<z.infer<typeof formSchema>>({
         resolver: zodResolver(formSchema),
         defaultValues: {
             alias: '',
-            number: '',
+            number: undefined,
             expiry: '',
-            cvc: '',
+            cvc: undefined,
             name: '',
         }
     });
@@ -74,7 +79,7 @@ export default function CreditCard() {
     }
 
     function onSubmit(values: z.infer<typeof formSchema>) {
-        addCreditCard({ ...values, userId: "" })
+        addCreditCard({ ...values, userId: decryptedUser.userEmail })
         form.reset();
         setOpen(false);
     }
@@ -137,10 +142,13 @@ export default function CreditCard() {
                                         <FormControl>
                                             <Input
                                                 type="number"
-                                                name="number"
+                                                name={field.name}
                                                 placeholder="Número do cartão"
                                                 value={state.number}
-                                                onChange={handleInputChange}
+                                                onChange={(event) => {
+                                                    field.onChange(event);
+                                                    handleInputChange(event);
+                                                }}
                                                 onFocus={handleInputFocus}
                                             />
                                         </FormControl>
@@ -158,10 +166,13 @@ export default function CreditCard() {
                                         <FormControl>
                                             <Input
                                                 type="name"
-                                                name="name"
+                                                name={field.name}
                                                 placeholder="Nome"
                                                 value={state.name}
-                                                onChange={handleInputChange}
+                                                onChange={(event) => {
+                                                    field.onChange(event);
+                                                    handleInputChange(event);
+                                                }}
                                                 onFocus={handleInputFocus}
                                             />
                                         </FormControl>
@@ -180,10 +191,13 @@ export default function CreditCard() {
                                             <FormControl>
                                                 <Input
                                                     type="expiry"
-                                                    name="expiry"
+                                                    name={field.name}
                                                     placeholder="Data expiração (MM/AA)"
                                                     value={state.expiry}
-                                                    onChange={handleInputChange}
+                                                    onChange={(event) => {
+                                                        field.onChange(event);
+                                                        handleInputChange(event);
+                                                    }}
                                                     onFocus={handleInputFocus}
 
                                                 />
@@ -195,19 +209,21 @@ export default function CreditCard() {
 
                                 <FormField
                                     control={form.control}
-                                    name="expiry"
+                                    name="cvc"
                                     render={({ field }) => (
                                         <FormItem>
                                             <FormLabel></FormLabel>
                                             <FormControl>
                                                 <Input
                                                     type="cvc"
-                                                    name="cvc"
+                                                    name={field.name}
                                                     placeholder="CVC"
                                                     value={state.cvc}
-                                                    onChange={handleInputChange}
+                                                    onChange={(event) => {
+                                                        field.onChange(event);
+                                                        handleInputChange(event);
+                                                    }}
                                                     onFocus={handleInputFocus}
-
                                                 />
                                             </FormControl>
                                             <FormMessage />

--- a/src/components/DataTableDialog/index.tsx
+++ b/src/components/DataTableDialog/index.tsx
@@ -33,7 +33,8 @@ export default function DataTableDialog(props: DataTableDialogProps) {
     
     let authStore = useAuthStore();
 
-    let { user } = authStore;
+    let { user, getUserInfo } = authStore;
+    const decryptedUser = getUserInfo(user)
 
     const capitalize = props.inputValue.charAt(0).toUpperCase() + props.inputValue.slice(1);
     const lowerCase = props.inputValue.toLowerCase();
@@ -47,7 +48,7 @@ export default function DataTableDialog(props: DataTableDialogProps) {
     });
 
     function onSubmit(values: z.infer<typeof formSchema>) {
-        props.addValue({...values, email: user})
+        props.addValue({...values, email: decryptedUser.userEmail})
         form.reset();
         setOpen(false);
     }

--- a/src/components/DataTableDialog/index.tsx
+++ b/src/components/DataTableDialog/index.tsx
@@ -9,7 +9,6 @@ import {
     DialogHeader,
     DialogTitle,
     DialogTrigger,
-    DialogDescription
 } from "@/components/ui/dialog"
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
@@ -66,7 +65,6 @@ export default function DataTableDialog(props: DataTableDialogProps) {
                 </Button>
             </DialogTrigger>
             <DialogContent className="sm:max-w-[425px]">
-                <DialogDescription />
                 <Form {...form}>
                     <form onSubmit={
                         e => {

--- a/src/components/NewTransactionModal/index.tsx
+++ b/src/components/NewTransactionModal/index.tsx
@@ -26,7 +26,6 @@ import {
     DialogTitle,
     DialogTrigger,
     DialogClose,
-    DialogDescription,
 } from "@/components/ui/dialog"
 import { useState } from 'react';
 import {
@@ -44,6 +43,7 @@ import {
 } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { ScrollArea } from '../ui/scroll-area';
+import CreditCard from '../CreditCard';
 
 const ACCEPTED_IMAGE_TYPES = ["image/jpeg", "image/jpg", "image/png", "image/webp"];
 
@@ -53,6 +53,7 @@ const formSchema = z.object({
     }),
     //coerce used to fix input number value
     amount: z.coerce.number().positive({ message: "O valor deve ser maior que zero!" }),
+    creditCard: z.string(),
     type: z.union([
         z.literal('deposit'),
         z.literal('withdraw'),
@@ -146,7 +147,6 @@ export default function NewTransactionModal() {
                 </Button>
             </DialogTrigger>
             <DialogContent>
-                <DialogDescription />
                 <DialogHeader>
                     <DialogTitle>Nova Transação</DialogTitle>
                 </DialogHeader>
@@ -155,7 +155,6 @@ export default function NewTransactionModal() {
                         <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col justify-center items-center h-fit py-4 space-y-10">
 
                             <div className='space-y-6'>
-
                                 <FormField
                                     control={form.control}
                                     name="title"
@@ -178,6 +177,16 @@ export default function NewTransactionModal() {
                                                 <MoneyInput form={form} label='' placeholder='Preço' {...field} />
                                             </FormControl>
                                             <FormMessage />
+                                        </FormItem>
+                                    )}
+                                />
+
+                                <FormField
+                                    control={form.control}
+                                    name="creditCard"
+                                    render={({ field }) => (
+                                        <FormItem>
+                                            <CreditCard />
                                         </FormItem>
                                     )}
                                 />

--- a/src/services/actions/creditCardsActions.ts
+++ b/src/services/actions/creditCardsActions.ts
@@ -1,0 +1,20 @@
+import { db } from '../../../firebaseConfig';
+import { doc, setDoc } from "firebase/firestore";
+import { getCreditCardsAccess } from '../dataAccess/creditCardsAccess';
+import { CreditCardProps } from '@/stores/CreditCardStore';
+
+export async function getCreditCardsAction() {
+    const response = await getCreditCardsAccess();
+
+    const creditCards: any[] = [];
+    response.forEach((doc) => {
+        creditCards.push(doc.data());
+    })
+
+    return creditCards;
+}
+
+export async function addCreditCardsAction(creditCard: CreditCardProps) {
+    const docRef = doc(db, "creditCards", creditCard.id);
+    await setDoc(docRef, creditCard);
+}

--- a/src/services/dataAccess/creditCardsAccess.ts
+++ b/src/services/dataAccess/creditCardsAccess.ts
@@ -1,0 +1,9 @@
+import { db } from '../../../firebaseConfig'
+import { collection, query, getDocs } from "firebase/firestore";
+
+export async function getCreditCardsAccess() {
+    const q = query(collection(db, "creditCards"));
+    const response = await getDocs(q);
+
+    return response;
+}

--- a/src/stores/CreditCardStore.ts
+++ b/src/stores/CreditCardStore.ts
@@ -5,11 +5,11 @@ import { v4 as uuidv4 } from 'uuid';
 
 export type CreditCardProps = {
     id: string,
-    userId: string,
+    userId: string | null,
     alias: string,
-    number: string;
+    number: number;
     expiry: string;
-    cvc: string;
+    cvc: number;
     name: string;
 }
 

--- a/src/stores/CreditCardStore.ts
+++ b/src/stores/CreditCardStore.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import { toast } from "sonner";
+import { getCreditCardsAction, addCreditCardsAction } from "@/services/actions/creditCardsActions";
+import { v4 as uuidv4 } from 'uuid';
+
+export type CreditCardProps = {
+    id: string,
+    userId: string,
+    alias: string,
+    number: string;
+    expiry: string;
+    cvc: string;
+    name: string;
+}
+
+type CreditCardStoreProps = {
+    creditCards: CreditCardProps[],
+    error: null | string | unknown,
+    getCreditCards: () => void,
+    addCreditCard: (category: Omit<CreditCardProps, "id">) => void,
+}
+
+export const useCreditCardStore = create<CreditCardStoreProps>((set) => ({
+    creditCards: [],
+    error: null,
+    getCreditCards: async () => {
+        try {
+            const response = await getCreditCardsAction();
+            set({ creditCards: response })
+        } catch (error) {
+            set({ error })
+        }
+    },
+    addCreditCard: async (subcategory) => {
+        const data = { ...subcategory, id: uuidv4() };
+        await addCreditCardsAction(data);
+        try {
+            set((state) => ({
+                creditCards: [...state.creditCards, data]
+            }))
+            toast.success("Cartão adicionado!");
+        } catch (error) {
+            set({ error })
+        }
+    }
+}))


### PR DESCRIPTION
Ao cadastrar um cartão de crédito, o email do usuário atual é inserido no banco, para que ao selecionar os cartões, apareçam apenas aqueles que estejam associados. Como o cartão de crédito não será utilizado em alguma regra de negócio (sendo apenas para registro) as validações do Zod são pouco rigorosas (principalmente referente a tamanho de campos).


https://github.com/user-attachments/assets/05c1e68a-3ba3-474e-a834-8146d1a2c1ea

